### PR TITLE
GET /show/<queue_name>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "dibsv3"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Nate Tenczar <ntenczar@gmail.com>"]
 
 [dependencies]
-rocket = "0.3.6"
-rocket_codegen = "0.3.6"
-rocket_contrib = "0.3.6"
+rocket = "0.3.8"
+rocket_codegen = "0.3.8"
+rocket_contrib = "0.3.8"
 serde = "1.0"
 serde_derive = "1.0"
 diesel = { version = "1.1.1", features = ["postgres", "r2d2"] }
 dotenv = "0.9.0"
 uuid = { version = "0.6.0-beta", features = ["v4"] }
+chrono = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate uuid;
 extern crate rocket;
 extern crate rocket_contrib;
 
+extern crate chrono;
 #[macro_use]
 extern crate diesel;
 extern crate dotenv;
@@ -43,10 +44,15 @@ fn dequeue(
     return status::Accepted::<()>(None);
 }
 
+#[get("/show/<queue_name>")]
+fn show(db: State<DibsDB>, queue_name: String) -> Option<String> {
+    return db.show(queue_name);
+}
+
 fn main() {
     let db = DibsDB::new();
     rocket::ignite()
         .manage(db)
-        .mount("/", routes![queue, dequeue])
+        .mount("/", routes![queue, dequeue, show])
         .launch();
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,5 @@
 use std::time::SystemTime;
+use chrono::prelude::*;
 
 use schema::{queues, users};
 
@@ -10,12 +11,52 @@ pub struct Queue {
     pub created_at: SystemTime,
 }
 
+fn zero_pad(num: i64) -> String {
+    if num < 10 {
+        format!("0{}", num)
+    } else {
+        format!("{}", num)
+    }
+}
+
+impl Queue {
+    pub fn show(&self, users: Vec<User>) -> String {
+        let header = format!("{} Queue \n============ \n", self.title);
+        let mut body = String::from("");
+        if users.len() == 0 {
+            return format!("{} Queue is Empty.", self.title);
+        }
+        let now: DateTime<Utc> = Utc::now();
+        for u in users {
+            let formatted_user = u.show(now);
+            body = format!(
+                "{} in queue for {:?}\\n {}",
+                u.user_id, formatted_user, body
+            );
+        }
+        return format!("{}\\n {}", header, body);
+    }
+}
+
 #[derive(Identifiable, Queryable, Debug)]
 pub struct User {
     pub id: String,
     pub user_id: String,
     pub queue_id: String,
     pub created_at: SystemTime,
+}
+
+impl User {
+    pub fn show(&self, now: DateTime<Utc>) -> String {
+        let created_at: DateTime<Utc> = self.created_at.into();
+        let diff = now.signed_duration_since(created_at);
+        let hours = diff.num_hours();
+        let minutes = diff.num_minutes() - (hours * 60);
+        let seconds = diff.num_seconds() - (hours * 3600) - (minutes * 60);
+        let fmt_minutes = zero_pad(minutes);
+        let fmt_seconds = zero_pad(seconds);
+        return format!("{}:{}:{}", hours, fmt_minutes, fmt_seconds);
+    }
 }
 
 #[derive(Insertable, Debug)]


### PR DESCRIPTION
It now shows the queue name and a list of queued users. 

Responses look like:
```
foo Queue 
============ 
\n nate in queue for "0:00:20"\n 
```
```
foo Queue is Empty.
```

I'll fiddle with the formatting later once this is actually hooked up to slack.

Also:
- Upgrades rocket to a version that isn't currently broken on the Rust nightly
- adds `chrono` for time munging